### PR TITLE
[#32] Multiple parents implementation

### DIFF
--- a/lib/components/IntelligentTreeSelect.js
+++ b/lib/components/IntelligentTreeSelect.js
@@ -89,7 +89,6 @@ class IntelligentTreeSelect extends _react.Component {
     this._onChange = this._onChange.bind(this);
     this._onScroll = this._onScroll.bind(this);
     this._onOptionToggle = this._onOptionToggle.bind(this);
-    this._onOptionClose = this._onOptionClose.bind(this);
     this._finalizeSelectedOptions = this._finalizeSelectedOptions.bind(this);
     this.state = {
       expanded: this.props.expanded,
@@ -441,8 +440,6 @@ class IntelligentTreeSelect extends _react.Component {
 
   _onOptionToggle(option) {
     if (!option.expanded) {
-      option.expanded = true;
-
       let dataCached = this._isInHistory(option[this.props.valueKey]);
 
       if (!dataCached) {
@@ -477,22 +474,9 @@ class IntelligentTreeSelect extends _react.Component {
           });
         });
       }
-    } else {
-      this._onOptionClose(option);
     }
 
     this.forceUpdate();
-  }
-
-  _onOptionClose(option) {
-    if (option === undefined) return;
-    option.expanded = false;
-
-    for (const subTermId of option[this.props.childrenKey]) {
-      const subTerm = this.state.options.find((term) => term[this.props.valueKey] === subTermId);
-
-      this._onOptionClose(subTerm);
-    }
   }
 
   _valueRenderer({children, data}) {

--- a/lib/components/IntelligentTreeSelect.js
+++ b/lib/components/IntelligentTreeSelect.js
@@ -103,6 +103,7 @@ class IntelligentTreeSelect extends _react.Component {
   }
 
   componentDidMount() {
+    console.log("NEW SELECT MOUNTED");
     let data = [];
 
     if (this.props.name && this.props.fetchOptions) {

--- a/lib/components/IntelligentTreeSelect.js
+++ b/lib/components/IntelligentTreeSelect.js
@@ -103,7 +103,6 @@ class IntelligentTreeSelect extends _react.Component {
   }
 
   componentDidMount() {
-    console.log("NEW SELECT MOUNTED");
     let data = [];
 
     if (this.props.name && this.props.fetchOptions) {

--- a/lib/components/VirtualizedTreeSelect.js
+++ b/lib/components/VirtualizedTreeSelect.js
@@ -190,6 +190,7 @@ class VirtualizedTreeSelect extends _react.Component {
   }
 
   _findOption(dataset, searchedOption) {
+    if (!searchedOption || !dataset) return null;
     let options = dataset.filter((el) => el[this.props.valueKey] === searchedOption[this.props.valueKey]);
 
     for (const option of options) {
@@ -222,7 +223,8 @@ class VirtualizedTreeSelect extends _react.Component {
     visited.add(key);
     option.depth = depth;
     option.parent = parent;
-    option.path = [...visited]; //If the item already present, set the correct expanded value
+    option.path = [...visited];
+    option.expanded = false; //If the item already present, set the correct expanded value
 
     let existingOption = this._findOption(this.state.options, option);
 

--- a/lib/components/VirtualizedTreeSelect.js
+++ b/lib/components/VirtualizedTreeSelect.js
@@ -126,6 +126,9 @@ class VirtualizedTreeSelect extends _react.Component {
     this._onInputChange = this._onInputChange.bind(this);
     this.filterValues = this.filterValues.bind(this);
     this._onOptionToggle = this._onOptionToggle.bind(this);
+    this._findOption = this._findOption.bind(this);
+    this._findOptionWithParent = this._findOptionWithParent.bind(this);
+    this._onOptionClose = this._onOptionClose.bind(this);
     this._removeChildrenFromToggled = this._removeChildrenFromToggled.bind(this);
     this._onOptionSelect = this._onOptionSelect.bind(this);
     this.matchCheck = this.props.matchCheck || this.matchCheckFull;
@@ -164,24 +167,19 @@ class VirtualizedTreeSelect extends _react.Component {
     this.data = {};
     const keys = [];
     this.props.options.forEach((option) => {
-      option.expanded = option.expanded === undefined ? this.props.expanded : option.expanded;
       const optionID = option[this.props.valueKey];
       this.data[optionID] = option;
       keys.push(optionID);
     });
+    const sortedArr = [];
     keys.forEach((key) => {
       let option = this.data[key];
 
       if (!option.parent) {
-        this._calculateDepth(key, 0, null, new Set());
+        this._calculateDepth(key, 0, null, new Set(), sortedArr);
       }
     });
-    let options = [];
-    keys
-      .filter((key) => this.data[key].depth === 0)
-      .forEach((key) => {
-        this._sort(options, key, new Set());
-      }); // Value property is needed for correct rendering of selected options
+    let options = sortedArr; // Value property is needed for correct rendering of selected options
 
     options.forEach((option) => {
       option.value = option[this.props.valueKey];
@@ -191,38 +189,52 @@ class VirtualizedTreeSelect extends _react.Component {
     });
   }
 
-  _calculateDepth(key, depth, parentKey, visited) {
-    let option = this.data[key];
+  _findOption(dataset, searchedOption) {
+    let options = dataset.filter((el) => el[this.props.valueKey] === searchedOption[this.props.valueKey]);
+    let existingOption;
 
-    if (!option || visited.has(key)) {
-      return;
+    if (options && searchedOption.parent) {
+      existingOption = options.find(
+        (el) => el?.parent[this.props.valueKey] === searchedOption.parent[this.props.valueKey]
+      );
+    } else {
+      existingOption = options.length === 1 ? options[0] : null;
     }
 
-    visited.add(key);
-    option.depth = depth;
-
-    if (!option.parent) {
-      option.parent = parentKey;
-    }
-
-    option[this.props.childrenKey].forEach((childID) => {
-      this._calculateDepth(childID, depth + 1, key, visited);
-    });
+    return existingOption;
   }
 
-  _sort(sortedArr, key, visited) {
+  _findOptionWithParent(dataset, searchedOptionKey, parent) {
+    let options = dataset.filter((el) => el[this.props.valueKey] === searchedOptionKey);
+    return options.find((el) => el?.parent[this.props.valueKey] === parent[this.props.valueKey]);
+  }
+
+  _calculateDepth(key, depth, parent, visited, sortedArr) {
     let option = this.data[key];
 
     if (!option || visited.has(key)) {
       return;
     }
 
-    visited.add(key);
+    if (sortedArr.includes(option)) {
+      //Deep copy of option, needed to distinguish option for multiple subtrees
+      option = JSON.parse(JSON.stringify(option));
+    }
+
     sortedArr.push(option);
+    visited.add(key);
+    option.depth = depth;
+    option.parent = parent; //If the item already present, set the correct expanded value
+
+    let existingOption = this._findOption(this.state.options, option);
+
+    if (existingOption) {
+      option.expanded = existingOption.expanded;
+    }
+
     option[this.props.childrenKey].forEach((childID) => {
-      this._sort(sortedArr, childID, visited);
+      this._calculateDepth(childID, depth + 1, option, visited, sortedArr);
     });
-    return sortedArr;
   }
 
   filterOption(candidate, inputValue) {
@@ -230,7 +242,7 @@ class VirtualizedTreeSelect extends _react.Component {
     inputValue = inputValue.trim().toLowerCase();
 
     if (inputValue.length === 0) {
-      return !option.parent || this.data[option.parent]?.expanded;
+      return !option.parent || option.parent?.expanded;
     } else {
       return option.visible;
     }
@@ -256,7 +268,7 @@ class VirtualizedTreeSelect extends _react.Component {
 
     for (let match of matches) {
       while (match.parent !== null) {
-        match = this.data[match.parent];
+        match = match.parent;
         match.expanded = true;
         match.visible = true;
       }
@@ -283,9 +295,7 @@ class VirtualizedTreeSelect extends _react.Component {
 
     if (input.length === 0) {
       for (let option of this.state.options) {
-        option.expanded = !!this.toggledOptions.find(
-          (element) => element[this.props.valueKey] === option[this.props.valueKey]
-        );
+        option.expanded = !!this._findOption(this.toggledOptions, option);
       }
     }
   }
@@ -294,10 +304,24 @@ class VirtualizedTreeSelect extends _react.Component {
     if (option === undefined) return;
 
     for (const subTermId of option[this.props.childrenKey]) {
-      const subTerm = this.state.options.find((term) => term[this.props.valueKey] === subTermId);
-      this.toggledOptions = this.toggledOptions.filter((term) => term[this.props.valueKey] !== subTermId);
+      const subTerm = this._findOptionWithParent(this.state.options, subTermId, option);
+
+      const toggledItem = this._findOption(this.toggledOptions, subTerm);
+
+      this.toggledOptions = this.toggledOptions.filter((term) => term !== toggledItem);
 
       this._removeChildrenFromToggled(subTerm);
+    }
+  }
+
+  _onOptionClose(option) {
+    if (option === undefined) return;
+    option.expanded = false;
+
+    for (const subTermId of option[this.props.childrenKey]) {
+      const subTerm = this._findOptionWithParent(this.state.options, subTermId, option);
+
+      this._onOptionClose(subTerm);
     }
   }
 
@@ -309,12 +333,20 @@ class VirtualizedTreeSelect extends _react.Component {
 
     if ("onOptionToggle" in this.props) {
       this.props.onOptionToggle(option);
+    }
+
+    if (option.expanded) {
+      this._onOptionClose(option);
+    } else {
+      option.expanded = true;
     } // Adds/removes references for toggled items
 
     if (option.expanded) {
       this.toggledOptions.push(option);
     } else {
-      this.toggledOptions = this.toggledOptions.filter((el) => el[this.props.valueKey] !== option[this.props.valueKey]);
+      const toggledItem = this._findOption(this.toggledOptions, option);
+
+      this.toggledOptions = this.toggledOptions.filter((el) => el !== toggledItem);
 
       this._removeChildrenFromToggled(option);
     }
@@ -323,19 +355,19 @@ class VirtualizedTreeSelect extends _react.Component {
 
   _onOptionSelect(props) {
     props.selectOption(props.data);
-    let optionId = props.value;
     const isSelected = props.isSelected;
     if (isSelected) return;
-    let option = this.data[optionId];
-    let parent = this.data[option.parent];
+    let parent = props.data.parent;
 
     while (parent) {
-      if (!this.toggledOptions.find((el) => el[this.props.valueKey] === parent[this.props.valueKey])) {
+      let option = this._findOption(this.toggledOptions, parent);
+
+      if (!option) {
         parent.expanded = true;
         this.toggledOptions.push(parent);
       }
 
-      parent = this.data[parent.parent];
+      parent = option?.parent ?? parent.parent;
     }
   } //When using custom option, it is needed to set focusedOption manually
 

--- a/lib/components/VirtualizedTreeSelect.js
+++ b/lib/components/VirtualizedTreeSelect.js
@@ -191,22 +191,19 @@ class VirtualizedTreeSelect extends _react.Component {
 
   _findOption(dataset, searchedOption) {
     let options = dataset.filter((el) => el[this.props.valueKey] === searchedOption[this.props.valueKey]);
-    let existingOption;
 
-    if (options && searchedOption.parent) {
-      existingOption = options.find(
-        (el) => el?.parent[this.props.valueKey] === searchedOption.parent[this.props.valueKey]
-      );
-    } else {
-      existingOption = options.length === 1 ? options[0] : null;
+    for (const option of options) {
+      if ((0, _Utils.arraysAreEqual)(option.path, searchedOption.path)) {
+        return option;
+      }
     }
 
-    return existingOption;
+    return null;
   }
 
   _findOptionWithParent(dataset, searchedOptionKey, parent) {
     let options = dataset.filter((el) => el[this.props.valueKey] === searchedOptionKey);
-    return options.find((el) => el?.parent[this.props.valueKey] === parent[this.props.valueKey]);
+    return options.find((el) => el?.parent === parent);
   }
 
   _calculateDepth(key, depth, parent, visited, sortedArr) {
@@ -224,7 +221,8 @@ class VirtualizedTreeSelect extends _react.Component {
     sortedArr.push(option);
     visited.add(key);
     option.depth = depth;
-    option.parent = parent; //If the item already present, set the correct expanded value
+    option.parent = parent;
+    option.path = [...visited]; //If the item already present, set the correct expanded value
 
     let existingOption = this._findOption(this.state.options, option);
 

--- a/lib/components/VirtualizedTreeSelect.js
+++ b/lib/components/VirtualizedTreeSelect.js
@@ -212,7 +212,7 @@ class VirtualizedTreeSelect extends _react.Component {
 
     if (!option || visited.has(key)) {
       return;
-    }
+    } //Checks whether the array of items already contain an option with the same valueKey (ID)
 
     if (sortedArr.includes(option)) {
       //Deep copy of option, needed to distinguish option for multiple subtrees
@@ -220,11 +220,14 @@ class VirtualizedTreeSelect extends _react.Component {
     }
 
     sortedArr.push(option);
-    visited.add(key);
+    visited.add(key); //Sets the idempotent properties
+
     option.depth = depth;
     option.parent = parent;
     option.path = [...visited];
-    option.expanded = false; //If the item already present, set the correct expanded value
+    option.expanded = false; //It can happen that the option is already loaded in the state
+    //If so, set the correct expanded value from the state options
+    //It is needed to check it's full path to determine whether it is the correct option
 
     let existingOption = this._findOption(this.state.options, option);
 
@@ -331,9 +334,7 @@ class VirtualizedTreeSelect extends _react.Component {
       return;
     }
 
-    if ("onOptionToggle" in this.props) {
-      this.props.onOptionToggle(option);
-    }
+    this.props.onOptionToggle(option);
 
     if (option.expanded) {
       this._onOptionClose(option);

--- a/lib/components/utils/Utils.js
+++ b/lib/components/utils/Utils.js
@@ -1,8 +1,9 @@
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+  value: true,
 });
+exports.arraysAreEqual = arraysAreEqual;
 exports.getLabel = getLabel;
 exports.hashCode = hashCode;
 exports.isURL = isURL;
@@ -16,7 +17,7 @@ function hashCode(str) {
   let h = 0;
 
   for (let i = 0; i < str.length; i++) {
-    h = Math.imul(31, h) + str.charCodeAt(i) | 0;
+    h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
   }
 
   return h;
@@ -27,5 +28,17 @@ function isURL(str) {
 }
 
 function sanitizeArray(arr) {
-  return arr ? Array.isArray(arr) ? arr : [arr] : [];
+  return arr ? (Array.isArray(arr) ? arr : [arr]) : [];
+}
+
+function arraysAreEqual(a, b) {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (a.length !== b.length) return false;
+
+  for (let i = 0; i < a.length; ++i) {
+    if (a[i] !== b[i]) return false;
+  }
+
+  return true;
 }

--- a/src/components/IntelligentTreeSelect.js
+++ b/src/components/IntelligentTreeSelect.js
@@ -36,6 +36,7 @@ class IntelligentTreeSelect extends Component {
   }
 
   componentDidMount() {
+    console.log("NEW SELECT MOUNTED");
     let data = [];
     if (this.props.name && this.props.fetchOptions) {
       data = this._retrieveCachedData();
@@ -372,7 +373,6 @@ class IntelligentTreeSelect extends Component {
     if (this.props.valueRenderer) {
       // On initial render, there can be empty options
       if (!children) return null;
-
       return this.props.valueRenderer(children, data);
     }
     const {valueKey, labelKey, getOptionLabel} = this.props;

--- a/src/components/IntelligentTreeSelect.js
+++ b/src/components/IntelligentTreeSelect.js
@@ -36,7 +36,6 @@ class IntelligentTreeSelect extends Component {
   }
 
   componentDidMount() {
-    console.log("NEW SELECT MOUNTED");
     let data = [];
     if (this.props.name && this.props.fetchOptions) {
       data = this._retrieveCachedData();

--- a/src/components/IntelligentTreeSelect.js
+++ b/src/components/IntelligentTreeSelect.js
@@ -21,7 +21,6 @@ class IntelligentTreeSelect extends Component {
     this._onChange = this._onChange.bind(this);
     this._onScroll = this._onScroll.bind(this);
     this._onOptionToggle = this._onOptionToggle.bind(this);
-    this._onOptionClose = this._onOptionClose.bind(this);
     this._finalizeSelectedOptions = this._finalizeSelectedOptions.bind(this);
 
     this.state = {
@@ -336,7 +335,6 @@ class IntelligentTreeSelect extends Component {
 
   _onOptionToggle(option) {
     if (!option.expanded) {
-      option.expanded = true;
       let dataCached = this._isInHistory(option[this.props.valueKey]);
 
       if (!dataCached) {
@@ -366,20 +364,8 @@ class IntelligentTreeSelect extends Component {
           this.setState({isLoadingExternally: false});
         });
       }
-    } else {
-      this._onOptionClose(option);
     }
     this.forceUpdate();
-  }
-
-  _onOptionClose(option) {
-    if (option === undefined) return;
-
-    option.expanded = false;
-    for (const subTermId of option[this.props.childrenKey]) {
-      const subTerm = this.state.options.find((term) => term[this.props.valueKey] === subTermId);
-      this._onOptionClose(subTerm);
-    }
   }
 
   _valueRenderer({children, data}) {

--- a/src/components/VirtualizedTreeSelect.js
+++ b/src/components/VirtualizedTreeSelect.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import Option from "./Option";
 import Constants from "./utils/Constants";
 import {FixedSizeList as List} from "react-window";
-import {getLabel} from "./utils/Utils";
+import {getLabel, arraysAreEqual} from "./utils/Utils";
 
 class VirtualizedTreeSelect extends Component {
   constructor(props, context) {
@@ -81,20 +81,17 @@ class VirtualizedTreeSelect extends Component {
 
   _findOption(dataset, searchedOption) {
     let options = dataset.filter((el) => el[this.props.valueKey] === searchedOption[this.props.valueKey]);
-    let existingOption;
-    if (options && searchedOption.parent) {
-      existingOption = options.find(
-        (el) => el?.parent[this.props.valueKey] === searchedOption.parent[this.props.valueKey]
-      );
-    } else {
-      existingOption = options.length === 1 ? options[0] : null;
+    for (const option of options) {
+      if (arraysAreEqual(option.path, searchedOption.path)) {
+        return option;
+      }
     }
-    return existingOption;
+    return null;
   }
 
   _findOptionWithParent(dataset, searchedOptionKey, parent) {
     let options = dataset.filter((el) => el[this.props.valueKey] === searchedOptionKey);
-    return options.find((el) => el?.parent[this.props.valueKey] === parent[this.props.valueKey]);
+    return options.find((el) => el?.parent === parent);
   }
 
   _calculateDepth(key, depth, parent, visited, sortedArr) {
@@ -112,7 +109,7 @@ class VirtualizedTreeSelect extends Component {
     visited.add(key);
     option.depth = depth;
     option.parent = parent;
-
+    option.path = [...visited];
     //If the item already present, set the correct expanded value
     let existingOption = this._findOption(this.state.options, option);
     if (existingOption) {

--- a/src/components/VirtualizedTreeSelect.js
+++ b/src/components/VirtualizedTreeSelect.js
@@ -100,7 +100,7 @@ class VirtualizedTreeSelect extends Component {
     if (!option || visited.has(key)) {
       return;
     }
-
+    //Checks whether the array of items already contain an option with the same valueKey (ID)
     if (sortedArr.includes(option)) {
       //Deep copy of option, needed to distinguish option for multiple subtrees
       option = JSON.parse(JSON.stringify(option));
@@ -108,11 +108,16 @@ class VirtualizedTreeSelect extends Component {
 
     sortedArr.push(option);
     visited.add(key);
+
+    //Sets the idempotent properties
     option.depth = depth;
     option.parent = parent;
     option.path = [...visited];
     option.expanded = false;
-    //If the item already present, set the correct expanded value
+
+    //It can happen that the option is already loaded in the state
+    //If so, set the correct expanded value from the state options
+    //It is needed to check it's full path to determine whether it is the correct option
     let existingOption = this._findOption(this.state.options, option);
     if (existingOption) {
       option.expanded = existingOption.expanded;
@@ -206,9 +211,7 @@ class VirtualizedTreeSelect extends Component {
     if (this.searchString !== "") {
       return;
     }
-    if ("onOptionToggle" in this.props) {
-      this.props.onOptionToggle(option);
-    }
+    this.props.onOptionToggle(option);
 
     if (option.expanded) {
       this._onOptionClose(option);

--- a/src/components/VirtualizedTreeSelect.js
+++ b/src/components/VirtualizedTreeSelect.js
@@ -239,8 +239,8 @@ class VirtualizedTreeSelect extends Component {
     while (parent) {
       let option = this._findOption(this.toggledOptions, parent);
       if (!option) {
-        option.expanded = true;
-        this.toggledOptions.push(option);
+        parent.expanded = true;
+        this.toggledOptions.push(parent);
       }
       parent = option.parent;
     }

--- a/src/components/VirtualizedTreeSelect.js
+++ b/src/components/VirtualizedTreeSelect.js
@@ -242,7 +242,7 @@ class VirtualizedTreeSelect extends Component {
         parent.expanded = true;
         this.toggledOptions.push(parent);
       }
-      parent = option.parent;
+      parent = option?.parent ?? parent.parent;
     }
   }
 

--- a/src/components/VirtualizedTreeSelect.js
+++ b/src/components/VirtualizedTreeSelect.js
@@ -80,6 +80,7 @@ class VirtualizedTreeSelect extends Component {
   }
 
   _findOption(dataset, searchedOption) {
+    if (!searchedOption || !dataset) return null;
     let options = dataset.filter((el) => el[this.props.valueKey] === searchedOption[this.props.valueKey]);
     for (const option of options) {
       if (arraysAreEqual(option.path, searchedOption.path)) {
@@ -110,6 +111,7 @@ class VirtualizedTreeSelect extends Component {
     option.depth = depth;
     option.parent = parent;
     option.path = [...visited];
+    option.expanded = false;
     //If the item already present, set the correct expanded value
     let existingOption = this._findOption(this.state.options, option);
     if (existingOption) {

--- a/src/components/VirtualizedTreeSelect.js
+++ b/src/components/VirtualizedTreeSelect.js
@@ -231,19 +231,18 @@ class VirtualizedTreeSelect extends Component {
   //Path is saved in toggledOptions
   _onOptionSelect(props) {
     props.selectOption(props.data);
-    let optionId = props.value;
     const isSelected = props.isSelected;
 
     if (isSelected) return;
 
     let parent = props.data.parent;
-
     while (parent) {
-      if (!this.toggledOptions.includes(parent)) {
-        parent.expanded = true;
-        this.toggledOptions.push(parent);
+      let option = this._findOption(this.toggledOptions, parent);
+      if (!option) {
+        option.expanded = true;
+        this.toggledOptions.push(option);
       }
-      parent = parent.parent;
+      parent = option.parent;
     }
   }
 

--- a/src/components/utils/Utils.js
+++ b/src/components/utils/Utils.js
@@ -17,3 +17,13 @@ export function isURL(str) {
 export function sanitizeArray(arr) {
   return arr ? (Array.isArray(arr) ? arr : [arr]) : [];
 }
+
+export function arraysAreEqual(a, b) {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; ++i) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Component can now visualize terms in many subtrees. Tested on test/demo data + against the development branch on TermIt.
When selecting a term, only the subtree from which it was chosen is expanded. 
Example of multiple parent is shown below, terms: `ddd4` and `aaa1` have mupltiple parents
![image](https://user-images.githubusercontent.com/46053137/181047460-7183de5a-6198-445c-a8b7-7db3a33eb44f.png)



Resolves: https://github.com/lecbyjak/intelligent-tree-select/issues/32 

Please @ledsoft check it out and let me know what you think.

PS: If you are going to test it locally, the linking process between TermIt and this library needs to have the additional `--legacy-peer-deps` attribute. (at least from my experience)