### PR TITLE
[#47] Option selection when input is not focused

### DIFF
--- a/lib/components/VirtualizedTreeSelect.js
+++ b/lib/components/VirtualizedTreeSelect.js
@@ -509,7 +509,15 @@ const Menu = (props) => {
           onScrollCapture: (e) => {
             props.selectProps.listProps.onScroll(e.target);
           },
-          onMouseEnter: () => props.selectProps.focus(),
+          //Enables option selection even when input is not focused
+          onMouseDown: (event) => {
+            if (event.button !== 0) {
+              return;
+            }
+
+            event.stopPropagation();
+            event.preventDefault();
+          },
         }
       ),
     }),

--- a/lib/components/VirtualizedTreeSelect.js
+++ b/lib/components/VirtualizedTreeSelect.js
@@ -131,6 +131,7 @@ class VirtualizedTreeSelect extends _react.Component {
     this._onOptionClose = this._onOptionClose.bind(this);
     this._removeChildrenFromToggled = this._removeChildrenFromToggled.bind(this);
     this._onOptionSelect = this._onOptionSelect.bind(this);
+    this.focus = this.focus.bind(this);
     this.matchCheck = this.props.matchCheck || this.matchCheckFull;
     this.data = {};
     this.searchString = "";
@@ -152,9 +153,7 @@ class VirtualizedTreeSelect extends _react.Component {
   }
 
   focus() {
-    if (this.select.current) {
-      this.select.current.focus();
-    }
+    this.select.current.focus();
   }
 
   blurInput() {
@@ -411,6 +410,7 @@ class VirtualizedTreeSelect extends _react.Component {
           onOptionToggle: this._onOptionToggle,
           onOptionSelect: this._onOptionSelect,
           onOptionHover: this._onOptionHover,
+          focus: this.focus,
         }
       )
     );
@@ -509,6 +509,7 @@ const Menu = (props) => {
           onScrollCapture: (e) => {
             props.selectProps.listProps.onScroll(e.target);
           },
+          onMouseEnter: () => props.selectProps.focus(),
         }
       ),
     }),

--- a/src/components/VirtualizedTreeSelect.js
+++ b/src/components/VirtualizedTreeSelect.js
@@ -21,6 +21,7 @@ class VirtualizedTreeSelect extends Component {
     this._onOptionClose = this._onOptionClose.bind(this);
     this._removeChildrenFromToggled = this._removeChildrenFromToggled.bind(this);
     this._onOptionSelect = this._onOptionSelect.bind(this);
+    this.focus = this.focus.bind(this);
     this.matchCheck = this.props.matchCheck || this.matchCheckFull;
     this.data = {};
     this.searchString = "";
@@ -42,9 +43,7 @@ class VirtualizedTreeSelect extends Component {
   }
 
   focus() {
-    if (this.select.current) {
-      this.select.current.focus();
-    }
+    this.select.current.focus();
   }
 
   blurInput() {
@@ -280,6 +279,7 @@ class VirtualizedTreeSelect extends Component {
         onOptionToggle={this._onOptionToggle}
         onOptionSelect={this._onOptionSelect}
         onOptionHover={this._onOptionHover}
+        focus={this.focus}
       />
     );
   }
@@ -342,6 +342,7 @@ const Menu = (props) => {
         onScrollCapture: (e) => {
           props.selectProps.listProps.onScroll(e.target);
         },
+        onMouseEnter: () => props.selectProps.focus(),
       }}
     >
       {props.children}

--- a/src/components/VirtualizedTreeSelect.js
+++ b/src/components/VirtualizedTreeSelect.js
@@ -342,7 +342,14 @@ const Menu = (props) => {
         onScrollCapture: (e) => {
           props.selectProps.listProps.onScroll(e.target);
         },
-        onMouseEnter: () => props.selectProps.focus(),
+        //Enables option selection even when input is not focused
+        onMouseDown: (event) => {
+          if (event.button !== 0) {
+            return;
+          }
+          event.stopPropagation();
+          event.preventDefault();
+        },
       }}
     >
       {props.children}


### PR DESCRIPTION
When mouse enters the list, the focus is automatically added. It helps when menu is opened by default and user wants to select item => no need for double click.

cc: @ledsoft 

Resolves: #47 