### PR TITLE
[#50] Tree expansion - expanded prop

### DIFF
--- a/lib/components/VirtualizedTreeSelect.js
+++ b/lib/components/VirtualizedTreeSelect.js
@@ -138,7 +138,7 @@ class VirtualizedTreeSelect extends _react.Component {
     this.toggledOptions = [];
     this.state = {
       options: [],
-      expanded: false,
+      initialExpansion: false,
     };
     this.select = /*#__PURE__*/ _react.default.createRef();
   }
@@ -185,14 +185,14 @@ class VirtualizedTreeSelect extends _react.Component {
       option.value = option[this.props.valueKey];
     }); // Expands the whole tree on the initial render
 
-    if (this.props.expanded && !this.state.expanded && options.length > 0) {
+    if (this.props.expanded && !this.state.initialExpansion && options.length > 0) {
       for (const option of options) {
         this.toggledOptions.push(option);
         option.expanded = true;
       }
 
       this.setState({
-        expanded: true,
+        initialExpansion: true,
       });
     }
 

--- a/lib/components/VirtualizedTreeSelect.js
+++ b/lib/components/VirtualizedTreeSelect.js
@@ -138,6 +138,7 @@ class VirtualizedTreeSelect extends _react.Component {
     this.toggledOptions = [];
     this.state = {
       options: [],
+      expanded: false,
     };
     this.select = /*#__PURE__*/ _react.default.createRef();
   }
@@ -182,7 +183,19 @@ class VirtualizedTreeSelect extends _react.Component {
 
     options.forEach((option) => {
       option.value = option[this.props.valueKey];
-    });
+    }); // Expands the whole tree on the initial render
+
+    if (this.props.expanded && !this.state.expanded && options.length > 0) {
+      for (const option of options) {
+        this.toggledOptions.push(option);
+        option.expanded = true;
+      }
+
+      this.setState({
+        expanded: true,
+      });
+    }
+
     this.setState({
       options,
     });

--- a/src/components/VirtualizedTreeSelect.js
+++ b/src/components/VirtualizedTreeSelect.js
@@ -28,7 +28,7 @@ class VirtualizedTreeSelect extends Component {
     this.toggledOptions = [];
     this.state = {
       options: [],
-      expanded: false,
+      initialExpansion: false,
     };
     this.select = React.createRef();
   }
@@ -77,12 +77,12 @@ class VirtualizedTreeSelect extends Component {
     });
 
     // Expands the whole tree on the initial render
-    if (this.props.expanded && !this.state.expanded && options.length > 0) {
+    if (this.props.expanded && !this.state.initialExpansion && options.length > 0) {
       for (const option of options) {
         this.toggledOptions.push(option);
         option.expanded = true;
       }
-      this.setState({expanded: true});
+      this.setState({initialExpansion: true});
     }
 
     this.setState({options});

--- a/src/components/VirtualizedTreeSelect.js
+++ b/src/components/VirtualizedTreeSelect.js
@@ -28,6 +28,7 @@ class VirtualizedTreeSelect extends Component {
     this.toggledOptions = [];
     this.state = {
       options: [],
+      expanded: false,
     };
     this.select = React.createRef();
   }
@@ -74,6 +75,15 @@ class VirtualizedTreeSelect extends Component {
     options.forEach((option) => {
       option.value = option[this.props.valueKey];
     });
+
+    // Expands the whole tree on the initial render
+    if (this.props.expanded && !this.state.expanded && options.length > 0) {
+      for (const option of options) {
+        this.toggledOptions.push(option);
+        option.expanded = true;
+      }
+      this.setState({expanded: true});
+    }
 
     this.setState({options});
   }


### PR DESCRIPTION
The `expanded` prop now expands the whole tree on the initial render (until some data is loaded). These options are stored in the toggled array, so if user collapses some item and closes the dropdown, the tree stays in consistent state. That means that the prop doesn't force reopening of previously collapsed items.

Resolves: #50 