### PR TITLE
Fix cyclic refs

### DIFF
--- a/lib/components/VirtualizedTreeSelect.js
+++ b/lib/components/VirtualizedTreeSelect.js
@@ -227,7 +227,7 @@ class VirtualizedTreeSelect extends _react.Component {
 
     if (sortedArr.has(option)) {
       //Deep copy of option, needed to distinguish option for multiple subtrees
-      option = JSON.parse(JSON.stringify(option));
+      option = structuredClone(option);
     }
 
     sortedArr.add(option);

--- a/src/components/VirtualizedTreeSelect.js
+++ b/src/components/VirtualizedTreeSelect.js
@@ -110,7 +110,7 @@ class VirtualizedTreeSelect extends Component {
     //Checks whether the array of items already contain an option with the same valueKey (ID)
     if (sortedArr.has(option)) {
       //Deep copy of option, needed to distinguish option for multiple subtrees
-      option = JSON.parse(JSON.stringify(option));
+      option = structuredClone(option);
     }
 
     sortedArr.add(option);


### PR DESCRIPTION
Deep copy now uses `structuredClone` method which allows cyclic references. Since the library uses the options which are given to it, it might happen that some property of the object might have cyclic reference. 
@ledsoft Tested with TermIt and works fine

Closes: https://github.com/kbss-cvut/termit-ui/issues/378 