### PR TITLE
[Feat #597] Ability to flatten the list with renderAsTree property

### DIFF
--- a/examples/demo.js
+++ b/examples/demo.js
@@ -32,6 +32,7 @@ root.render(
     titleKey="http://www.w3.org/2000/01/rdf-schema#comment"
     simpleTreeData={true}
     options={data}
+    renderAsTree={true}
     isMenuOpen={true}
     displayInfoOnHover={true}
     onOptionCreate={(option) => {

--- a/src/components/VirtualizedTreeSelect.js
+++ b/src/components/VirtualizedTreeSelect.js
@@ -92,14 +92,13 @@ class VirtualizedTreeSelect extends Component {
       }
     } else {
       // Flat list processing - just use all options without hierarchy
-      options = this.props.options.map((option) => {
-        const processedOption = {...option};
-        processedOption.depth = 0;
-        processedOption.parent = null;
-        processedOption.expanded = false;
-        processedOption.visible = true;
-        return processedOption;
-      });
+      options = this.props.options.slice();
+      for (const option of options) {
+        option.depth = 0;
+        option.parent = null;
+        option.expanded = false;
+        option.visible = true;
+      }
     }
 
     this.setState({options});


### PR DESCRIPTION
Update to renderAsTree property
- when set to true (default), the component builds and displays a hierarchical tree structure.
- when set to false, the component flattens the list and renders all options without hierarchy.
